### PR TITLE
3-add-logger: Enable the logger for the app

### DIFF
--- a/code/robotic-factory-simulator/fr.tp.inf112.projects.robotsim/config/SimulatorApplication.launch
+++ b/code/robotic-factory-simulator/fr.tp.inf112.projects.robotsim/config/SimulatorApplication.launch
@@ -14,4 +14,5 @@
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="fr.tp.inf112.projects.robotsim.app.SimulatorApplication"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="fr.tp.inf112.projects.robotsim"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="fr.tp.inf112.projects.robotsim"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Djava.util.logging.config.file=config/logging.properties"/>
 </launchConfiguration>

--- a/code/robotic-factory-simulator/fr.tp.inf112.projects.robotsim/config/logging.properties
+++ b/code/robotic-factory-simulator/fr.tp.inf112.projects.robotsim/config/logging.properties
@@ -1,0 +1,63 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.
+# For example, java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma-separated list of log Handler
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+#handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overridden by a facility-specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level=CONFIG
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = config/robotsim%u.log
+java.util.logging.FileHandler.limit = 1000000
+java.util.logging.FileHandler.count = 1
+# Default number of locks FileHandler can obtain synchronously.
+# This specifies maximum number of attempts to obtain lock file by FileHandler
+# implemented by incrementing the unique field %u as per FileHandler API documentation.
+java.util.logging.FileHandler.maxLocks = 100
+java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+
+# Limit the messages that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = CONFIG
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Example to customize the SimpleFormatter output format
+# to print one-line log message like this:
+#     <level>: <log message> [<date/time>]
+#
+# java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
+
+############################################################
+# Facility-specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+# com.xyz.foo.level = SEVERE

--- a/code/robotic-factory-simulator/fr.tp.inf112.projects.robotsim/src/fr/tp/inf112/projects/robotsim/app/SimulatorApplication.java
+++ b/code/robotic-factory-simulator/fr.tp.inf112.projects.robotsim/src/fr/tp/inf112/projects/robotsim/app/SimulatorApplication.java
@@ -2,6 +2,7 @@ package fr.tp.inf112.projects.robotsim.app;
 
 import java.awt.Component;
 import java.util.Arrays;
+import java.util.logging.Logger;
 
 import javax.swing.SwingUtilities;
 
@@ -28,9 +29,11 @@ import fr.tp.inf112.projects.robotsim.model.shapes.RectangularShape;
 public class SimulatorApplication {
 
 	public static void main(String[] args) {
-		System.out.println("Starting the robot simulator...");
 		
-		System.out.println("With parameters " + Arrays.toString(args) + ".");
+		/* Instantiate logger */ 
+		final Logger LOGGER = Logger.getLogger(SimulatorApplication.class.getName());
+		LOGGER.info("Starting the robot simulator..");
+		LOGGER.config("With parameters " + Arrays.toString(args) + ".");
 		
 		final Factory factory = new Factory(200, 200, "Simple Test Puck Factory");
 		final Room room1 = new Room(factory, new RectangularShape(20, 20, 75, 75), "Production Room 1");

--- a/code/robotic-factory-simulator/fr.tp.inf112.projects.robotsim/src/fr/tp/inf112/projects/robotsim/model/path/AbstractFactoryPathFinder.java
+++ b/code/robotic-factory-simulator/fr.tp.inf112.projects.robotsim/src/fr/tp/inf112/projects/robotsim/model/path/AbstractFactoryPathFinder.java
@@ -4,7 +4,9 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.logging.Logger;
 
+import fr.tp.inf112.projects.robotsim.app.SimulatorApplication;
 import fr.tp.inf112.projects.robotsim.model.Factory;
 import fr.tp.inf112.projects.robotsim.model.Position;
 import fr.tp.inf112.projects.robotsim.model.shapes.PositionedShape;
@@ -22,6 +24,8 @@ public abstract class AbstractFactoryPathFinder<Graph, Vertex> implements Factor
 	private final int resolution;
 	
 	private transient Graph graph;
+	
+	private static transient final Logger LOGGER = Logger.getLogger(AbstractFactoryPathFinder.class.getName());
 
 	public AbstractFactoryPathFinder(final Factory factoryModel,
 									 final int resolution) {
@@ -67,7 +71,7 @@ public abstract class AbstractFactoryPathFinder<Graph, Vertex> implements Factor
 				}
 			}
 			
-			System.out.println(graph.toString());
+			LOGGER.info(graph.toString());
 		}
 	}
 	


### PR DESCRIPTION
- Config a java logger in order to be able to print messages both in the console and on a logging file
- Increase the logging capacity of the file in because the 500kB is too little for the full log of the Path
- Refactor the app to use Logger.* instead of System.out.println